### PR TITLE
Change database name to match up with automated scripts

### DIFF
--- a/SED/settings.py
+++ b/SED/settings.py
@@ -113,7 +113,7 @@ WSGI_APPLICATION = 'SED.wsgi.application'
 DATABASES = {
    'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'sed_database',
+        'NAME': 'SED_Database',
         'MYSQL_USER': 'sed_admin',
         'USER': 'sed_admin',
         'PASSWORD':'sed_password',


### PR DESCRIPTION
Database names are case-sensitive when run in a MySQL Linux container. This update will bring parity with the database name in the Ansible script and in the test data SQL scripts.