### PR TITLE
Fix Django migrate command in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,4 @@ ADD . /app
 WORKDIR /app
 RUN pip install -r requirements.txt
 EXPOSE 8000
-CMD ["python", "manage.py", "collectstatic"]
-CMD ["python", "manage.py", "syncdb", "--noinput"]
-CMD ["python", "manage.py", "migrate", "--noinput"]
-CMD ["python","manage.py","runserver","0.0.0.0:8000"]
-
-
-
+CMD ["/bin/bash","start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install -r requirements.txt
 EXPOSE 8000
 CMD ["python", "manage.py", "collectstatic"]
 CMD ["python", "manage.py", "syncdb", "--noinput"]
-CMD ["python", "manage.py", "migrate", "__noinput"]
+CMD ["python", "manage.py", "migrate", "--noinput"]
 CMD ["python","manage.py","runserver","0.0.0.0:8000"]
 
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+python manage.py migrate --noinput
+python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
This fixes the --noinput flag for Django setup/migrate in the Dockerfile. This fixes a database error on the Contact page which occurs because the django_session table is missing.